### PR TITLE
Feature: ocultar eventos pasados del dashboard por defecto

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
+from django.utils import timezone
 
 from category.models import Category
 
@@ -40,6 +41,14 @@ class Event(models.Model):
 
     def __str__(self):
         return self.title
+    
+    @classmethod
+    def get_upcoming_events(cls):
+        return cls.objects.filter(scheduled_at__gte=timezone.now()).order_by("scheduled_at")
+    
+    @classmethod
+    def get_all_events(cls):
+        return cls.objects.all().order_by("scheduled_at")
 
     @classmethod
     def validate(cls, title, description, scheduled_at):

--- a/app/models.py
+++ b/app/models.py
@@ -44,7 +44,7 @@ class Event(models.Model):
     
     @classmethod
     def get_upcoming_events(cls):
-        return cls.objects.filter(scheduled_at__gte=timezone.now()).order_by("scheduled_at")
+        return cls.objects.filter(scheduled_at__gte=timezone.localtime()).order_by("scheduled_at")
     
     @classmethod
     def get_all_events(cls):

--- a/app/models.py
+++ b/app/models.py
@@ -48,7 +48,7 @@ class Event(models.Model):
     
     @classmethod
     def get_all_events(cls):
-        return cls.objects.all().order_by("scheduled_at")
+        return cls.objects.all().order_by("scheduled_at").reverse()
 
     @classmethod
     def validate(cls, title, description, scheduled_at):

--- a/app/models.py
+++ b/app/models.py
@@ -48,7 +48,7 @@ class Event(models.Model):
     
     @classmethod
     def get_all_events(cls):
-        return cls.objects.all().order_by("scheduled_at").reverse()
+        return cls.objects.all().order_by("scheduled_at")#.reverse()
 
     @classmethod
     def validate(cls, title, description, scheduled_at):

--- a/app/templates/app/event_form.html
+++ b/app/templates/app/event_form.html
@@ -48,7 +48,7 @@
         </div>
 
         <div class="pt-2">
-            <button type="submit" class="btn btn-primary">
+            <button type="submit" class="btn btn-primary" name="Guardar">
                 Guardar
             </button>
         </div>

--- a/app/templates/app/events.html
+++ b/app/templates/app/events.html
@@ -21,6 +21,7 @@
             <a
               href="{% url 'event_form' %}"
               class="btn btn-primary"
+              name="Crear Evento"
             >
               <i class="bi bi-plus-circle me-2" aria-hidden="true"></i>
               Crear Evento
@@ -36,6 +37,7 @@
             class="form-check-input"
             type="checkbox"
             id="showPastSwitch"
+            name="showPastSwitch"
             {% if request.resolver_match.url_name == 'events_all' %}checked{% endif %}
             onchange="
               window.location.href = this.checked
@@ -84,6 +86,7 @@
                             </a>
                             {% if user_is_organizer %}
                                 <a href="{% url 'event_edit' event.id %}"
+                                    name="Editar"
                                     class="btn btn-sm btn-outline-secondary"
                                     aria-label="Editar"
                                     title="Editar">
@@ -92,7 +95,7 @@
                                 <form action="{% url 'event_delete' event.id %}" method="POST">
                                     {% csrf_token %}
                                     <button class="btn btn-sm btn-outline-danger"
-                                        title="Eliminar"
+                                        name="Eliminar"
                                         type="submit"
                                         aria-label="Eliminar"
                                         titile="Eliminar">

--- a/app/templates/app/events.html
+++ b/app/templates/app/events.html
@@ -6,6 +6,9 @@
 <div class="container p-4">
     <div class="d-flex py-4 justify-content-between align-items-center mb-4">
         <h1>Eventos</h1>
+        <div class="d-flex align-items-center gap-3">
+            <!-- Switch para mostrar/ocultar pasados -->
+            
         {% if user_is_organizer %}
         <div class="d-flex">
             <a
@@ -26,6 +29,25 @@
           
         {% endif %}
     </div>
+    </div>
+    <div class="d-flex justify-content-end mb-3">
+        <div class="form-check form-switch">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="showPastSwitch"
+            {% if request.resolver_match.url_name == 'events_all' %}checked{% endif %}
+            onchange="
+              window.location.href = this.checked
+            ? '{% url 'events_all' %}'
+            : '{% url 'events' %}';
+            "
+          >
+          <label class="form-check-label" for="showPastSwitch">
+            Mostrar eventos pasados
+          </label>
+        </div>
+      </div>
     <table class="table">
         <thead>
             <tr>

--- a/app/test/test_e2e/test_events.py
+++ b/app/test/test_e2e/test_events.py
@@ -226,7 +226,7 @@ class EventCRUDTest(EventBaseTest):
         # Completar el formulario
         self.page.get_by_label("Título del Evento").fill("Evento de prueba E2E")
         self.page.get_by_label("Descripción").fill("Descripción creada desde prueba E2E")
-        self.page.get_by_label("Fecha").fill((timezone.now() + datetime.timedelta(days=60)).strftime("%Y-%m-%d"))
+        self.page.get_by_label("Fecha").fill((timezone.localtime() + datetime.timedelta(days=60)).strftime("%Y-%m-%d"))
         self.page.get_by_label("Hora").fill("16:45")
 
         # Enviar el formulario
@@ -244,7 +244,7 @@ class EventCRUDTest(EventBaseTest):
 
         row = self.page.locator("table tbody tr").last
         expect(row.locator("td").nth(0)).to_have_text("Evento de prueba E2E")
-        expect(row.locator("td").nth(1)).to_have_text(timezone.localtime(timezone.now() + datetime.timedelta(days=60)).strftime("%d %b %Y").lower() + ", 16:45")
+        expect(row.locator("td").nth(1)).to_have_text(timezone.localtime(timezone.localtime() + datetime.timedelta(days=60)).strftime("%d %b %Y").lower() + ", 16:45")
 
     def test_edit_event_organizer(self):
         """Test que verifica la funcionalidad de editar un evento para organizadores"""
@@ -275,7 +275,7 @@ class EventCRUDTest(EventBaseTest):
 
         date = self.page.get_by_label("Fecha")
         expect(date).to_have_value(self.event1.scheduled_at.strftime("%Y-%m-%d"))
-        date.fill((timezone.now() + datetime.timedelta(days=60)).strftime("%Y-%m-%d"))
+        date.fill((timezone.localtime() + datetime.timedelta(days=60)).strftime("%Y-%m-%d"))
 
         time = self.page.get_by_label("Hora")
         expect(time).to_have_value(self.event1.scheduled_at.strftime("%H:%M"))
@@ -293,7 +293,7 @@ class EventCRUDTest(EventBaseTest):
         # Verificar que el título del evento ha sido actualizado
         row = self.page.locator("table tbody tr").last
         expect(row.locator("td").nth(0)).to_have_text("Titulo editado")
-        expect(row.locator("td").nth(1)).to_have_text(timezone.localtime(timezone.now() + datetime.timedelta(days=60)).strftime("%d %b %Y").lower() + ", 03:00")
+        expect(row.locator("td").nth(1)).to_have_text(timezone.localtime(timezone.localtime() + datetime.timedelta(days=60)).strftime("%d %b %Y").lower() + ", 03:00")
 
     def test_delete_event_organizer(self):
         """Test que verifica la funcionalidad de eliminar un evento para organizadores"""

--- a/app/test/test_e2e/test_events.py
+++ b/app/test/test_e2e/test_events.py
@@ -9,11 +9,6 @@ from app.models import Event, User
 
 from app.test.test_e2e.base import BaseE2ETest
 
-def fmt_like_template(dt):
-    return date_format(
-        timezone.localtime(dt), "d M Y, H:i", use_l10n=True
-    ).lower()
-
 class EventBaseTest(BaseE2ETest):
     """Clase base específica para tests de eventos"""
 
@@ -38,7 +33,7 @@ class EventBaseTest(BaseE2ETest):
 
         # Crear eventos de prueba
         # Evento 1
-        event_date1 = timezone.now() - datetime.timedelta(days=60)
+        event_date1 = timezone.localtime() - datetime.timedelta(days=60)
         self.event1 = Event.objects.create(
             title="Evento de prueba 1",
             description="Descripción del evento 1",
@@ -47,7 +42,7 @@ class EventBaseTest(BaseE2ETest):
         )
 
         # Evento 2
-        event_date2 = timezone.now() - datetime.timedelta(days=50)
+        event_date2 = timezone.localtime() - datetime.timedelta(days=50)
         self.event2 = Event.objects.create(
             title="Evento de prueba 2",
             description="Descripción del evento 2",
@@ -72,14 +67,15 @@ class EventBaseTest(BaseE2ETest):
         # Verificar datos del primer evento
         row0 = rows.nth(0)
         expect(row0.locator("td").nth(0)).to_have_text("Evento de prueba 1")
-        expect(row0.locator("td").nth(1)).to_have_text(fmt_like_template(self.event1.scheduled_at))
+        expected_date = date_format(self.event1.scheduled_at, "d M Y, H:i", use_l10n=True).lower()
+        expect(row0.locator("td").nth(1)).to_have_text(expected_date)
         expect(row0.locator("td").nth(2)).to_have_text("organizador")
 
         # Verificar datos del segundo evento
         row1 = rows.nth(1)
         expect(row1.locator("td").nth(0)).to_have_text("Evento de prueba 2")
-        expect(row1.locator("td").nth(1)).to_have_text(fmt_like_template(self.event2.scheduled_at))
-        expect(row1.locator("td").nth(2)).to_have_text("organizador")
+        expected_date = date_format(self.event2.scheduled_at, "d M Y, H:i", use_l10n=True).lower()
+        expect(row1.locator("td").nth(1)).to_have_text(expected_date)
 
     def _table_has_correct_actions(self, user_type):
         """Método auxiliar para verificar que las acciones son correctas según el tipo de usuario"""

--- a/app/test/test_e2e/test_events.py
+++ b/app/test/test_e2e/test_events.py
@@ -3,11 +3,16 @@ import re
 
 from django.utils import timezone
 from playwright.sync_api import expect
+from django.utils.formats import date_format
 
 from app.models import Event, User
 
 from app.test.test_e2e.base import BaseE2ETest
 
+def fmt_like_template(dt):
+    return date_format(
+        timezone.localtime(dt), "d M Y, H:i", use_l10n=True
+    ).lower()
 
 class EventBaseTest(BaseE2ETest):
     """Clase base específica para tests de eventos"""
@@ -33,7 +38,7 @@ class EventBaseTest(BaseE2ETest):
 
         # Crear eventos de prueba
         # Evento 1
-        event_date1 = timezone.make_aware(datetime.datetime(2025, 2, 10, 10, 10))
+        event_date1 = timezone.now() - datetime.timedelta(days=60)
         self.event1 = Event.objects.create(
             title="Evento de prueba 1",
             description="Descripción del evento 1",
@@ -42,7 +47,7 @@ class EventBaseTest(BaseE2ETest):
         )
 
         # Evento 2
-        event_date2 = timezone.make_aware(datetime.datetime(2025, 3, 15, 14, 30))
+        event_date2 = timezone.now() - datetime.timedelta(days=50)
         self.event2 = Event.objects.create(
             title="Evento de prueba 2",
             description="Descripción del evento 2",
@@ -67,13 +72,13 @@ class EventBaseTest(BaseE2ETest):
         # Verificar datos del primer evento
         row0 = rows.nth(0)
         expect(row0.locator("td").nth(0)).to_have_text("Evento de prueba 1")
-        expect(row0.locator("td").nth(1)).to_have_text("10 feb 2025, 10:10")
+        expect(row0.locator("td").nth(1)).to_have_text(fmt_like_template(self.event1.scheduled_at))
         expect(row0.locator("td").nth(2)).to_have_text("organizador")
 
         # Verificar datos del segundo evento
         row1 = rows.nth(1)
         expect(row1.locator("td").nth(0)).to_have_text("Evento de prueba 2")
-        expect(row1.locator("td").nth(1)).to_have_text("15 mar 2025, 14:30")
+        expect(row1.locator("td").nth(1)).to_have_text(fmt_like_template(self.event2.scheduled_at))
         expect(row1.locator("td").nth(2)).to_have_text("organizador")
 
     def _table_has_correct_actions(self, user_type):
@@ -225,7 +230,7 @@ class EventCRUDTest(EventBaseTest):
         # Completar el formulario
         self.page.get_by_label("Título del Evento").fill("Evento de prueba E2E")
         self.page.get_by_label("Descripción").fill("Descripción creada desde prueba E2E")
-        self.page.get_by_label("Fecha").fill("2025-06-15")
+        self.page.get_by_label("Fecha").fill((timezone.now() + datetime.timedelta(days=60)).strftime("%Y-%m-%d"))
         self.page.get_by_label("Hora").fill("16:45")
 
         # Enviar el formulario
@@ -243,7 +248,7 @@ class EventCRUDTest(EventBaseTest):
 
         row = self.page.locator("table tbody tr").last
         expect(row.locator("td").nth(0)).to_have_text("Evento de prueba E2E")
-        expect(row.locator("td").nth(1)).to_have_text("15 jun 2025, 16:45")
+        expect(row.locator("td").nth(1)).to_have_text(timezone.localtime(timezone.now() + datetime.timedelta(days=60)).strftime("%d %b %Y").lower() + ", 16:45")
 
     def test_edit_event_organizer(self):
         """Test que verifica la funcionalidad de editar un evento para organizadores"""
@@ -273,11 +278,11 @@ class EventCRUDTest(EventBaseTest):
         description.fill("Descripcion Editada")
 
         date = self.page.get_by_label("Fecha")
-        expect(date).to_have_value("2025-02-10")
-        date.fill("2025-04-20")
+        expect(date).to_have_value(self.event1.scheduled_at.strftime("%Y-%m-%d"))
+        date.fill((timezone.now() + datetime.timedelta(days=60)).strftime("%Y-%m-%d"))
 
         time = self.page.get_by_label("Hora")
-        expect(time).to_have_value("10:10")
+        expect(time).to_have_value(self.event1.scheduled_at.strftime("%H:%M"))
         time.fill("03:00")
 
         # Enviar el formulario
@@ -292,7 +297,7 @@ class EventCRUDTest(EventBaseTest):
         # Verificar que el título del evento ha sido actualizado
         row = self.page.locator("table tbody tr").last
         expect(row.locator("td").nth(0)).to_have_text("Titulo editado")
-        expect(row.locator("td").nth(1)).to_have_text("20 abr 2025, 03:00")
+        expect(row.locator("td").nth(1)).to_have_text(timezone.localtime(timezone.now() + datetime.timedelta(days=60)).strftime("%d %b %Y").lower() + ", 03:00")
 
     def test_delete_event_organizer(self):
         """Test que verifica la funcionalidad de eliminar un evento para organizadores"""

--- a/app/test/test_integration/test_event.py
+++ b/app/test/test_integration/test_event.py
@@ -274,11 +274,12 @@ class EventFormSubmissionTest(BaseEventTestCase):
         self.assertTrue(Event.objects.filter(title="Nuevo Evento").exists())
         evento = Event.objects.get(title="Nuevo Evento")
         self.assertEqual(evento.description, "Descripción del nuevo evento")
-        self.assertEqual(evento.scheduled_at.year, 2025)
-        self.assertEqual(evento.scheduled_at.month, 5)
-        self.assertEqual(evento.scheduled_at.day, 1)
-        self.assertEqual(evento.scheduled_at.hour, 14)
-        self.assertEqual(evento.scheduled_at.minute, 30)
+        scheduled_at = timezone.localtime(evento.scheduled_at)
+        self.assertEqual(scheduled_at.year, 2025)
+        self.assertEqual(scheduled_at.month, 5)
+        self.assertEqual(scheduled_at.day, 1)
+        self.assertEqual(scheduled_at.hour, 14)
+        self.assertEqual(scheduled_at.minute, 30)
         self.assertEqual(evento.organizer, self.organizer)
 
     def test_event_form_post_edit(self):
@@ -304,13 +305,15 @@ class EventFormSubmissionTest(BaseEventTestCase):
         # Verificar que el evento fue actualizado
         self.event1.refresh_from_db()
 
+
         self.assertEqual(self.event1.title, "Evento 1 Actualizado")
         self.assertEqual(self.event1.description, "Nueva descripción actualizada")
-        self.assertEqual(self.event1.scheduled_at.year, 2025)
-        self.assertEqual(self.event1.scheduled_at.month, 6)
-        self.assertEqual(self.event1.scheduled_at.day, 15)
-        self.assertEqual(self.event1.scheduled_at.hour, 16)
-        self.assertEqual(self.event1.scheduled_at.minute, 45)
+        scheduled_at = timezone.localtime(self.event1.scheduled_at)
+        self.assertEqual(scheduled_at.year, 2025)
+        self.assertEqual(scheduled_at.month, 6)
+        self.assertEqual(scheduled_at.day, 15)
+        self.assertEqual(scheduled_at.hour, 16)
+        self.assertEqual(scheduled_at.minute, 45)
 
 
 class EventDeleteViewTest(BaseEventTestCase):

--- a/app/test/test_integration/test_event.py
+++ b/app/test/test_integration/test_event.py
@@ -43,12 +43,76 @@ class BaseEventTestCase(TestCase):
             organizer=self.organizer,
         )
 
+        # Crear algunos eventos de prueba pasados
+        self.event3 = Event.objects.create(
+            title="Evento 3",
+            description="Descripción del evento 3",
+            scheduled_at=timezone.now() - datetime.timedelta(days=1),
+            organizer=self.organizer,
+        )
+
+        self.event4 = Event.objects.create(
+            title="Evento 4",
+            description="Descripción del evento 4",
+            scheduled_at=timezone.now() - datetime.timedelta(days=2),
+            organizer=self.organizer,
+        )
+
         # Cliente para hacer peticiones
         self.client = Client()
 
 
 class EventsListViewTest(BaseEventTestCase):
     """Tests para la vista de listado de eventos"""
+
+    def test_events_url_shows_only_future_regular_user(self):
+        """Test que verifica que la vista events muestra solo eventos futuros"""
+
+        # login con usuario regular
+        self.client.login(username="regular", password="password123")
+        resp = self.client.get(reverse("events"))
+        events_ctx = list(resp.context["events"])
+        self.assertEqual(len(events_ctx), 2)
+        self.assertIn(self.event1, events_ctx)
+        self.assertIn(self.event2, events_ctx)
+        self.assertNotIn(self.event3, events_ctx)
+        self.assertNotIn(self.event4, events_ctx)
+    
+    def test_events_url_shows_only_future_organizer(self):
+        """Test que verifica que la vista events muestra solo eventos futuros"""
+
+        # login con usuario organizador
+        self.client.login(username="organizador", password="password123")
+        resp = self.client.get(reverse("events"))
+        events_ctx = list(resp.context["events"])
+        self.assertEqual(len(events_ctx), 2)
+        self.assertIn(self.event1, events_ctx)
+        self.assertIn(self.event2, events_ctx)
+        self.assertNotIn(self.event3, events_ctx)
+        self.assertNotIn(self.event4, events_ctx)
+
+    def test_events_all_url_shows_past_and_future_regular_user(self):
+
+        # login con usuario regular
+        self.client.login(username="regular", password="password123")
+        resp = self.client.get(reverse("events_all"))
+        events_ctx = list(resp.context["events"])
+        self.assertEqual(len(events_ctx), 4)
+        self.assertIn(self.event1, events_ctx)
+        self.assertIn(self.event2, events_ctx)
+        self.assertIn(self.event3, events_ctx)
+        self.assertIn(self.event4, events_ctx)
+
+    def test_events_all_url_shows_past_and_future_organizer(self):
+        # login con usuario organizador
+        self.client.login(username="organizador", password="password123")
+        resp = self.client.get(reverse("events_all"))
+        events_ctx = list(resp.context["events"])
+        self.assertEqual(len(events_ctx), 4)
+        self.assertIn(self.event1, events_ctx)
+        self.assertIn(self.event2, events_ctx)
+        self.assertIn(self.event3, events_ctx)
+        self.assertIn(self.event4, events_ctx)
 
     def test_events_view_with_login(self):
         """Test que verifica que la vista events funciona cuando el usuario está logueado"""

--- a/app/test/test_unit/test_events_display.py
+++ b/app/test/test_unit/test_events_display.py
@@ -1,0 +1,56 @@
+import datetime
+
+from django.test import TestCase
+from django.utils import timezone
+
+from app.models import Category, Event, User
+
+
+class EventModelTest(TestCase):
+    def setUp(self):
+        self.organizer = User.objects.create_user(
+            username="organizador_test",
+            email="organizador@example.com",
+            password="password123",
+            is_organizer=True,
+        )
+
+        cat = Category.objects.create(name="General")
+
+        now = timezone.now()
+        self.past_event_1 = Event.objects.create(
+            title="Pasado 1", description="...", scheduled_at=now - datetime.timedelta(days=1), organizer=self.organizer
+        )
+        self.past_event_2 = Event.objects.create(
+            title="Pasado 2", description="...", scheduled_at=now - datetime.timedelta(days=2), organizer=self.organizer
+        )
+        self.future_event_1 = Event.objects.create(
+            title="Futuro 1", description="...", scheduled_at=now + datetime.timedelta(days=1), organizer=self.organizer
+        )
+        self.future_event_2 = Event.objects.create(
+            title="Futuro 2", description="...", scheduled_at=now + datetime.timedelta(days=2), organizer=self.organizer
+        )
+        self.future_event_3 = Event.objects.create(
+            title="Futuro 3", description="...", scheduled_at=now + datetime.timedelta(days=2), organizer=self.organizer
+        )
+        self.past_event_1.categories.add(cat)
+        self.past_event_2.categories.add(cat)
+        self.future_event_1.categories.add(cat)
+        self.future_event_2.categories.add(cat)
+    
+    def test_get_upcoming_events(self):
+        qs = Event.get_upcoming_events()
+        self.assertEqual(len(qs), 3)
+        self.assertIn(self.future_event_1, qs)
+        self.assertIn(self.future_event_2, qs)
+        self.assertIn(self.future_event_3, qs)
+        self.assertNotIn(self.past_event_1, qs)
+        self.assertNotIn(self.past_event_2, qs)
+
+    def test_get_all_events(self):
+        qs = Event.get_all_events()
+        self.assertEqual(len(qs), 5)
+        self.assertIn(self.future_event_1, qs)
+        self.assertIn(self.future_event_2, qs)
+        self.assertIn(self.past_event_1, qs)
+        self.assertIn(self.past_event_2, qs)

--- a/app/urls.py
+++ b/app/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("accounts/logout/", LogoutView.as_view(), name="logout"),
     path("accounts/login/", views.login_view, name="login"),
     path("events/", views.events, name="events"),
+    path("events/all/", views.events, name="events_all"),
     path("events/create/", views.event_form, name="event_form"),
     path("events/<int:id>/edit/", views.event_form, name="event_edit"),
     path("events/<int:id>/", views.event_detail, name="event_detail"),

--- a/app/views.py
+++ b/app/views.py
@@ -65,7 +65,12 @@ def home(request):
 
 @login_required
 def events(request):
-    events = Event.objects.all().order_by("scheduled_at")
+    url_name = request.resolver_match.url_name
+    show_past = (url_name == "events_all")
+    if show_past:
+        events = Event.get_all_events()
+    else:
+        events = Event.get_upcoming_events()
     return render(
         request,
         "app/events.html",

--- a/eventhub/settings.py
+++ b/eventhub/settings.py
@@ -118,7 +118,7 @@ STATICFILES_DIRS = [BASE_DIR / "static"]
 AUTH_USER_MODEL = "app.User"
 LANGUAGE_CODE = "es-ar"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "America/Argentina/Buenos_Aires"
 
 USE_I18N = True
 


### PR DESCRIPTION
resolves #1 

El issue #1 solicitaba que, al abrir la sección Eventos, solo se mostraran los futuros y que existiera una forma sencilla de ver los históricos si fuera necesario.

resolves #1 