### PR TITLE
Fix/solucionar tests e2e de eventos y advertencias de ruff

### DIFF
--- a/app/test/test_e2e/test_event_status_e2e.py
+++ b/app/test/test_e2e/test_event_status_e2e.py
@@ -1,13 +1,13 @@
 import datetime
 import re
 
-from playwright.sync_api import expect
 from django.urls import reverse
 from django.utils import timezone
+from playwright.sync_api import expect
 
 from app.models import Event, User
-from category.models import Category
 from app.test.test_e2e.base import BaseE2ETest
+from category.models import Category
 
 
 class EventStatusE2ETest(BaseE2ETest):
@@ -67,7 +67,7 @@ class EventStatusE2ETest(BaseE2ETest):
         self.page.fill("input[name='time']", future_time)
 
         # Seleccionar categoría (checkbox)
-        category_checkbox_selector = f"input[name='categories'][value='{self.category.id}']"
+        category_checkbox_selector = f"input[name='categories'][value='{self.category.pk}']"
         self.page.locator(category_checkbox_selector).wait_for(state='visible')
         self.page.locator(category_checkbox_selector).check()
 
@@ -132,7 +132,7 @@ class EventStatusE2ETest(BaseE2ETest):
         edit_link_locator.click()
 
         self.page.wait_for_load_state('domcontentloaded')
-        expect(self.page).to_have_url(re.compile(self.live_server_url + expected_edit_url_path + r"$"))
+        expect(self.page).to_have_url(re.compile(self.live_server_url + str(expected_edit_url_path) + r"$"))
 
         # Seleccionar el nuevo status 'cancelado'
         self.page.locator("select[name='status']").wait_for(state='visible')

--- a/app/test/test_e2e/test_favorite_events.py
+++ b/app/test/test_e2e/test_favorite_events.py
@@ -1,9 +1,12 @@
 import datetime
+import re
+
 from django.utils import timezone
 from playwright.sync_api import expect
-from app.models import User, Event
+
+from app.models import Event, User
 from app.test.test_e2e.base import BaseE2ETest
-import re
+
 
 class FavoriteEventsE2ETest(BaseE2ETest):
     def setUp(self):

--- a/app/test/test_e2e/test_ratings.py
+++ b/app/test/test_e2e/test_ratings.py
@@ -1,12 +1,14 @@
 # Test e2e para event_rating_avg
 
 import datetime
-from django.utils import timezone
 
+from django.utils import timezone
 from playwright.sync_api import expect
+
 from app.models import Event, User
-from rating.models import Rating
 from app.test.test_e2e.base import BaseE2ETest
+from rating.models import Rating
+
 
 class TestEventRatingsE2E(BaseE2ETest):
     def setUp(self):

--- a/app/test/test_e2e/test_refunds.py
+++ b/app/test/test_e2e/test_refunds.py
@@ -1,6 +1,9 @@
 from playwright.sync_api import expect
+
 from refunds.models import Refund
+
 from .base import BaseE2ETest
+
 
 class RefundCreationE2ETest(BaseE2ETest):
 

--- a/app/test/test_integration/test_event.py
+++ b/app/test/test_integration/test_event.py
@@ -1,5 +1,4 @@
 import datetime
-import time
 
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -136,8 +135,8 @@ class EventsListViewTest(BaseEventTestCase):
 
         # Verificar que los eventos están ordenados por fecha
         events = list(response.context["events"])
-        self.assertEqual(events[0].id, self.event1.id)
-        self.assertEqual(events[1].id, self.event2.id)
+        self.assertEqual(events[0].pk, self.event1.pk)
+        self.assertEqual(events[1].pk, self.event2.pk)
 
     def test_events_view_with_organizer_login(self):
         """Test que verifica que la vista events funciona cuando el usuario es organizador"""
@@ -158,7 +157,7 @@ class EventsListViewTest(BaseEventTestCase):
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/"))
+        self.assertTrue(response['Location'].startswith("/accounts/login/"))
 
 
 class EventDetailViewTest(BaseEventTestCase):
@@ -170,22 +169,22 @@ class EventDetailViewTest(BaseEventTestCase):
         self.client.login(username="regular", password="password123")
 
         # Hacer petición a la vista event_detail
-        response = self.client.get(reverse("event_detail", args=[self.event1.id]))
+        response = self.client.get(reverse("event_detail", args=[self.event1.pk]))
 
         # Verificar respuesta
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "app/event_detail.html")
         self.assertIn("event", response.context)
-        self.assertEqual(response.context["event"].id, self.event1.id)
+        self.assertEqual(response.context["event"].pk, self.event1.pk)
 
     def test_event_detail_view_without_login(self):
         """Test que verifica que la vista event_detail redirige a login cuando el usuario no está logueado"""
         # Hacer petición a la vista event_detail sin login
-        response = self.client.get(reverse("event_detail", args=[self.event1.id]))
+        response = self.client.get(reverse("event_detail", args=[self.event1.pk]))
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/"))
+        self.assertTrue(response['Location'].startswith("/accounts/login/"))
 
     def test_event_detail_view_with_invalid_id(self):
         """Test que verifica que la vista event_detail devuelve 404 cuando el evento no existe"""
@@ -225,8 +224,7 @@ class EventFormViewTest(BaseEventTestCase):
         response = self.client.get(reverse("event_form"))
 
         # Verificar que redirecciona a events
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("events"))
+        self.assertRedirects(response, reverse("events"))
 
     def test_event_form_view_without_login(self):
         """Test que verifica que la vista event_form redirige a login cuando el usuario no está logueado"""
@@ -235,7 +233,7 @@ class EventFormViewTest(BaseEventTestCase):
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/"))
+        self.assertTrue(response['Location'].startswith("/accounts/login/"))
 
     def test_event_form_edit_existing(self):
         """Test que verifica que se puede editar un evento existente"""
@@ -243,12 +241,12 @@ class EventFormViewTest(BaseEventTestCase):
         self.client.login(username="organizador", password="password123")
 
         # Hacer petición a la vista event_form para editar evento existente
-        response = self.client.get(reverse("event_edit", args=[self.event1.id]))
+        response = self.client.get(reverse("event_edit", args=[self.event1.pk]))
 
         # Verificar respuesta
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "app/event_form.html")
-        self.assertEqual(response.context["event"].id, self.event1.id)
+        self.assertEqual(response.context["event"].pk, self.event1.pk)
 
 
 class EventFormSubmissionTest(BaseEventTestCase):
@@ -272,8 +270,7 @@ class EventFormSubmissionTest(BaseEventTestCase):
         response = self.client.post(reverse("event_form"), event_data)
 
         # Verificar que redirecciona a events
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("events"))
+        self.assertRedirects(response, reverse("events"))
 
         # Verificar que se creó el evento
         self.assertTrue(Event.objects.filter(title="Nuevo Evento").exists())
@@ -303,11 +300,10 @@ class EventFormSubmissionTest(BaseEventTestCase):
         }
 
         # Hacer petición POST para editar el evento
-        response = self.client.post(reverse("event_edit", args=[self.event1.id]), updated_data)
+        response = self.client.post(reverse("event_edit", args=[self.event1.pk]), updated_data)
 
         # Verificar que redirecciona a events
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("events"))
+        self.assertRedirects(response, reverse("events"))
 
         # Verificar que el evento fue actualizado
         self.event1.refresh_from_db()
@@ -333,16 +329,16 @@ class EventDeleteViewTest(BaseEventTestCase):
         self.client.login(username="organizador", password="password123")
 
         # Verificar que el evento existe antes de eliminar
-        self.assertTrue(Event.objects.filter(pk=self.event1.id).exists())
+        self.assertTrue(Event.objects.filter(pk=self.event1.pk).exists())
 
         # Hacer una petición POST para eliminar el evento
-        response = self.client.post(reverse("event_delete", args=[self.event1.id]))
+        response = self.client.post(reverse("event_delete", args=[self.event1.pk]))
 
         # Verificar que redirecciona a la página de eventos
         self.assertRedirects(response, reverse("events"))
 
         # Verificar que el evento ya no existe
-        self.assertFalse(Event.objects.filter(pk=self.event1.id).exists())
+        self.assertFalse(Event.objects.filter(pk=self.event1.pk).exists())
 
     def test_event_delete_with_regular_user(self):
         """Test que verifica que un usuario regular no puede eliminar un evento"""
@@ -350,16 +346,16 @@ class EventDeleteViewTest(BaseEventTestCase):
         self.client.login(username="regular", password="password123")
 
         # Verificar que el evento existe antes de intentar eliminarlo
-        self.assertTrue(Event.objects.filter(pk=self.event1.id).exists())
+        self.assertTrue(Event.objects.filter(pk=self.event1.pk).exists())
 
         # Hacer una petición POST para intentar eliminar el evento
-        response = self.client.post(reverse("event_delete", args=[self.event1.id]))
+        response = self.client.post(reverse("event_delete", args=[self.event1.pk]))
 
         # Verificar que redirecciona a la página de eventos sin eliminar
         self.assertRedirects(response, reverse("events"))
 
         # Verificar que el evento sigue existiendo
-        self.assertTrue(Event.objects.filter(pk=self.event1.id).exists())
+        self.assertTrue(Event.objects.filter(pk=self.event1.pk).exists())
 
     def test_event_delete_with_get_request(self):
         """Test que verifica que la vista redirecciona si se usa GET en lugar de POST"""
@@ -367,13 +363,13 @@ class EventDeleteViewTest(BaseEventTestCase):
         self.client.login(username="organizador", password="password123")
 
         # Hacer una petición GET para intentar eliminar el evento
-        response = self.client.get(reverse("event_delete", args=[self.event1.id]))
+        response = self.client.get(reverse("event_delete", args=[self.event1.pk]))
 
         # Verificar que redirecciona a la página de eventos
         self.assertRedirects(response, reverse("events"))
 
         # Verificar que el evento sigue existiendo
-        self.assertTrue(Event.objects.filter(pk=self.event1.id).exists())
+        self.assertTrue(Event.objects.filter(pk=self.event1.pk).exists())
 
     def test_event_delete_nonexistent_event(self):
         """Test que verifica el comportamiento al intentar eliminar un evento inexistente"""
@@ -395,14 +391,14 @@ class EventDeleteViewTest(BaseEventTestCase):
     def test_event_delete_without_login(self):
         """Test que verifica que la vista redirecciona a login si el usuario no está autenticado"""
         # Verificar que el evento existe antes de intentar eliminarlo
-        self.assertTrue(Event.objects.filter(pk=self.event1.id).exists())
+        self.assertTrue(Event.objects.filter(pk=self.event1.pk).exists())
 
         # Hacer una petición POST sin iniciar sesión
-        response = self.client.post(reverse("event_delete", args=[self.event1.id]))
+        response = self.client.post(reverse("event_delete", args=[self.event1.pk]))
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/"))
+        self.assertTrue(response['Location'].startswith("/accounts/login/"))
 
         # Verificar que el evento sigue existiendo
-        self.assertTrue(Event.objects.filter(pk=self.event1.id).exists())
+        self.assertTrue(Event.objects.filter(pk=self.event1.pk).exists())

--- a/app/test/test_integration/test_event_status_integration.py
+++ b/app/test/test_integration/test_event_status_integration.py
@@ -1,9 +1,12 @@
 import datetime
+
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
+
 from app.models import Event, User
 from category.models import Category
+
 
 class EventStatusIntegrationTest(TestCase):
     """
@@ -45,7 +48,7 @@ class EventStatusIntegrationTest(TestCase):
             'description': 'Description for new event with status.',
             'date': event_date,
             'time': event_time,
-            'categories': [self.category_music.id],
+            'categories': [self.category_music.pk],
             'status': 'reprogramado', 
         })
 
@@ -63,12 +66,12 @@ class EventStatusIntegrationTest(TestCase):
         event_date = self.event_to_edit.scheduled_at.strftime('%Y-%m-%d')
         event_time = self.event_to_edit.scheduled_at.strftime('%H:%M')
 
-        response = self.client.post(reverse('event_edit', args=[self.event_to_edit.id]), {
+        response = self.client.post(reverse('event_edit', args=[self.event_to_edit.pk]), {
             'title': 'Event to Edit Status Int', 
             'description': 'Updated description for status test.',
             'date': event_date,
             'time': event_time,
-            'categories': [self.category_sports.id],
+            'categories': [self.category_sports.pk],
             'status': 'agotado', 
         })
 
@@ -90,7 +93,7 @@ class EventStatusIntegrationTest(TestCase):
             'description': 'Event with default status.',
             'date': event_date,
             'time': event_time,
-            'categories': [self.category_music.id],
+            'categories': [self.category_music.pk],
         })
 
         self.assertEqual(response.status_code, 302)

--- a/app/test/test_integration/test_favorite_events.py
+++ b/app/test/test_integration/test_favorite_events.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
 from django.urls import reverse
-from app.models import User, Event, Favorite
 from django.utils.timezone import now, timedelta
+
+from app.models import Event, Favorite, User
+
 
 class FavoriteViewTest(TestCase):
     def setUp(self):
@@ -15,7 +17,7 @@ class FavoriteViewTest(TestCase):
 
     def test_toggle_favorite_add(self):
         self.client.login(username='user', password='password')
-        url = reverse('toggle_favorite', args=[self.event.id])
+        url = reverse('toggle_favorite', args=[self.event.pk])
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
@@ -24,7 +26,7 @@ class FavoriteViewTest(TestCase):
     def test_toggle_favorite_remove(self):
         self.client.login(username='user', password='password')
         Favorite.objects.create(user=self.user, event=self.event)
-        url = reverse('toggle_favorite', args=[self.event.id])
+        url = reverse('toggle_favorite', args=[self.event.pk])
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)

--- a/app/test/test_integration/test_refunds.py
+++ b/app/test/test_integration/test_refunds.py
@@ -1,4 +1,4 @@
-from django.test import Client,TestCase
+from django.test import Client, TestCase
 from django.urls import reverse
 
 from app.models import User

--- a/app/test/test_unit/test_event.py
+++ b/app/test/test_unit/test_event.py
@@ -1,5 +1,4 @@
 import datetime
-import time
 
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -123,7 +122,7 @@ class EventModelTest(TestCase):
 
         self.assertFalse(success)
         self.assertIsNotNone(errors)
-        self.assertIn("title", errors)
+        self.assertIn("title", errors or {})
         self.assertFalse(
             Event.objects.filter(
                 title=title, description=description, scheduled_at=scheduled_at, organizer=self.organizer
@@ -200,13 +199,12 @@ class EventViewTests(BaseEventTestCase):
         """Test que verifica la eliminación exitosa de un evento"""
         self.client.login(username="organizador", password="password123")
 
-        self.assertTrue(Event.objects.filter(pk=self.event1.id).exists())
+        self.assertTrue(Event.objects.filter(pk=self.event1.pk).exists())
 
-        response = self.client.post(reverse("event_delete", args=[self.event1.id]))
+        response = self.client.post(reverse("event_delete", args=[self.event1.pk]))
 
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("events"))
-        self.assertFalse(Event.objects.filter(pk=self.event1.id).exists())
+        self.assertRedirects(response, reverse("events"))
+        self.assertFalse(Event.objects.filter(pk=self.event1.pk).exists())
 
     def test_event_delete_nonexistent_event(self):
         """Test que verifica el comportamiento al intentar eliminar un evento inexistente"""
@@ -225,9 +223,9 @@ class EventViewTests(BaseEventTestCase):
 
     def test_event_delete_without_login(self):
         """Test que verifica que la vista redirecciona a login si el usuario no está autenticado"""
-        self.assertTrue(Event.objects.filter(pk=self.event1.id).exists())
+        self.assertTrue(Event.objects.filter(pk=self.event1.pk).exists())
 
-        response = self.client.post(reverse("event_delete", args=[self.event1.id]))
+        response = self.client.post(reverse("event_delete", args=[self.event1.pk]))
 
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/"))
+        self.assertTrue(response['Location'].startswith("/accounts/login/"))

--- a/app/test/test_unit/test_favorite_events.py
+++ b/app/test/test_unit/test_favorite_events.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
-from app.models import User, Event, Favorite
-from category.models import Category
 from django.utils.timezone import now, timedelta
+
+from app.models import Event, Favorite, User
+from category.models import Category
+
 
 class FavoriteModelTest(TestCase):
     def setUp(self):

--- a/app/test/test_unit/test_refunds.py
+++ b/app/test/test_unit/test_refunds.py
@@ -1,8 +1,9 @@
-from django.test import TestCase
 from django.core.exceptions import ValidationError
+from django.test import TestCase
 
 from app.models import User
 from refunds.models import Refund
+
 
 class RefundTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
Se solucionaron los siguientes problemas:

- Tests e2e de eventos que estaban fallando.
- Se ajustó la sintaxis del código para que Ruff no marque advertencias.

Cambios realizados:
- Corrección en archivos de prueba.
- Ajustes de formato y estilo en varios archivos para cumplir con las reglas de Ruff.

Los tests ahora pasan correctamente y el código queda limpio según el linter.