### PR TITLE
Se implementa la validacion del test de integracion de actualizacion mediante mensajes de error que se proporcionan en la view

### DIFF
--- a/app/test/test_integration/test_tickets.py
+++ b/app/test/test_integration/test_tickets.py
@@ -1,3 +1,4 @@
+from django.contrib.messages import get_messages
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -66,6 +67,13 @@ class TicketSimpleIntegrationTest(TestCase):
         )
 
         self.assertRedirects(response, reverse('tickets:actualizacion', args=[self.event.id])) # type: ignore
+        
+        #valida que se muestra un mensaje de error
+        messages = list(get_messages(response.wsgi_request))
+        self.assertTrue(len(messages) > 0)
+        self.assertTrue(any('Ticket' in str(message) for message in messages))
+        
+        #verifico que no se actualizó el ticket
         ticket1.refresh_from_db()
         self.assertEqual(ticket1.quantity, 2)
         


### PR DESCRIPTION
Utilizo los mensajes de error que se retornan de la view para validar en el caso del post con mas de 4 tickets
- de esta manera que chequeamos de forma correcta que funcione como debe ser el test de manera mas fiel.
Ahora deberian los test de integracion de tickets estar resueltos de manera correcta.
Resolves #18 